### PR TITLE
Refactors application and cuts down on network calls

### DIFF
--- a/src/components/ballot.jsx
+++ b/src/components/ballot.jsx
@@ -1,14 +1,11 @@
 import { useState, useRef, useEffect } from 'react';
 import ClipboardButton from './clipboardButton';
-import { fetchBallotById, formatTimeLeft } from '../utils';
+import { formatTimeLeft } from '../utils';
 
-export default function Ballot({ id }) {
+export default function Ballot({ ballot }) {
 
-    const [ballot, setBallot] = useState({ pubId: null, title: "", seconds_since_creation: null, exp_s: null, responses: [] });
     const [secondsLeft, setSecondsLeft] = useState(ballot.exp_s - ballot.seconds_since_creation);
-    const [timeRunning, setTimeRunning] = useState(false);
     let intervalRef = useRef();
-
 
     // const debug = {
     //     ballot_created: new Date(ballot.created_utc),
@@ -19,22 +16,10 @@ export default function Ballot({ id }) {
     // console.log("Time since creation in seconds: " + (debug.now - debug.ballot_created) / 1000);
 
     useEffect(() => {
-        async function fetchData() {
-            setBallot(await fetchBallotById(id));
-        }
-        fetchData();
+        intervalRef.current = setInterval(() => setSecondsLeft(prev => prev - 1), 1000);
 
         return () => clearInterval(intervalRef.current);
     }, []);
-
-    useEffect(() => {
-        setSecondsLeft(ballot.exp_s - ballot.seconds_since_creation);
-        if (!timeRunning) {
-            intervalRef.current = setInterval(() => setSecondsLeft(prev => prev - 1), 1000);
-            setTimeRunning(true)
-        }
-    }, [ballot]);
-
 
     const renderResponses = responses => {
         return responses.map(r => (

--- a/src/components/ballot.jsx
+++ b/src/components/ballot.jsx
@@ -9,6 +9,15 @@ export default function Ballot({ id }) {
     const [timeRunning, setTimeRunning] = useState(false);
     let intervalRef = useRef();
 
+
+    // const debug = {
+    //     ballot_created: new Date(ballot.created_utc),
+    //     now: new Date(),
+    // };
+    // console.log("Ballot created at: " + debug.ballot_created);
+    // console.log("Right now: " + debug.now);
+    // console.log("Time since creation in seconds: " + (debug.now - debug.ballot_created) / 1000);
+
     useEffect(() => {
         async function fetchData() {
             setBallot(await fetchBallotById(id));

--- a/src/components/ballot.jsx
+++ b/src/components/ballot.jsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import ClipboardButton from './clipboardButton';
 import { formatTimeLeft } from '../utils';
 
-export default function ShowBallot({ ballot }) {
+export default function Ballot({ ballot }) {
     const [secondsLeft, setSecondsLeft] = useState(ballot.exp_s - ballot.seconds_since_creation);
 
     let intervalRef = useRef();

--- a/src/components/ballot.jsx
+++ b/src/components/ballot.jsx
@@ -7,14 +7,6 @@ export default function Ballot({ ballot }) {
     const [secondsLeft, setSecondsLeft] = useState(calculateExpiry(ballot));
     let intervalRef = useRef();
 
-    // const debug = {
-    //     ballot_created: new Date(ballot.created_utc),
-    //     now: new Date(),
-    // };
-    // console.log("Ballot created at: " + debug.ballot_created);
-    // console.log("Right now: " + debug.now);
-    // console.log("Time since creation in seconds: " + (debug.now - debug.ballot_created) / 1000);
-
     useEffect(() => {
         intervalRef.current = setInterval(() => setSecondsLeft(prev => prev - 1), 1000);
 

--- a/src/components/ballot.jsx
+++ b/src/components/ballot.jsx
@@ -1,10 +1,10 @@
 import { useState, useRef, useEffect } from 'react';
 import ClipboardButton from './clipboardButton';
-import { formatTimeLeft } from '../utils';
+import { calculateExpiry, formatTimeLeft } from '../utils';
 
 export default function Ballot({ ballot }) {
 
-    const [secondsLeft, setSecondsLeft] = useState(ballot.exp_s - ballot.seconds_since_creation);
+    const [secondsLeft, setSecondsLeft] = useState(calculateExpiry(ballot));
     let intervalRef = useRef();
 
     // const debug = {
@@ -21,8 +21,15 @@ export default function Ballot({ ballot }) {
         return () => clearInterval(intervalRef.current);
     }, []);
 
-    const renderResponses = responses => {
-        return responses.map(r => (
+    useEffect(() => {
+        if (secondsLeft <= 0) {
+            setSecondsLeft(0);
+            clearInterval(intervalRef.current);
+        }
+    }, [secondsLeft]);
+
+    const renderResponses = () => {
+        return ballot.responses.map(r => (
             <div className='responses' key={r.pubId}>
                 <h2 className='response-title'>{r.content}</h2>
                 <p>Votes: {r.votes}</p>
@@ -34,7 +41,7 @@ export default function Ballot({ ballot }) {
             <h1>{ballot.title}</h1>
             <ClipboardButton />
             <p id='time-left'>{formatTimeLeft(secondsLeft)}</p>
-            {renderResponses(ballot.responses)}
+            {renderResponses()}
         </div>
     );
 }

--- a/src/components/ballot.jsx
+++ b/src/components/ballot.jsx
@@ -1,17 +1,31 @@
 import { useState, useRef, useEffect } from 'react';
 import ClipboardButton from './clipboardButton';
-import { formatTimeLeft } from '../utils';
+import { fetchBallotById, formatTimeLeft } from '../utils';
 
-export default function Ballot({ ballot }) {
+export default function Ballot({ id }) {
+
+    const [ballot, setBallot] = useState({ pubId: null, title: "", seconds_since_creation: null, exp_s: null, responses: [] });
     const [secondsLeft, setSecondsLeft] = useState(ballot.exp_s - ballot.seconds_since_creation);
-
+    const [timeRunning, setTimeRunning] = useState(false);
     let intervalRef = useRef();
 
     useEffect(() => {
-        intervalRef.current = setInterval(() => setSecondsLeft(prev => prev - 1), 1000);
+        async function fetchData() {
+            setBallot(await fetchBallotById(id));
+        }
+        fetchData();
 
         return () => clearInterval(intervalRef.current);
     }, []);
+
+    useEffect(() => {
+        setSecondsLeft(ballot.exp_s - ballot.seconds_since_creation);
+        if (!timeRunning) {
+            intervalRef.current = setInterval(() => setSecondsLeft(prev => prev - 1), 1000);
+            setTimeRunning(true)
+        }
+    }, [ballot]);
+
 
     const renderResponses = responses => {
         return responses.map(r => (

--- a/src/components/clipboardButton.jsx
+++ b/src/components/clipboardButton.jsx
@@ -29,7 +29,7 @@ export default function ClipboardButton() {
 
     return (
         <div id='clip-btn-container'>
-            <button onClick={handleClick} id='clipboard-btn'>{buttonText}</button>;
+            <button onClick={handleClick} id='clipboard-btn'>{buttonText}</button>
         </div>
     );
 }

--- a/src/components/hello.jsx
+++ b/src/components/hello.jsx
@@ -1,0 +1,9 @@
+export default function HelloMessage() {
+    return (
+        <div id="intro-message">
+            <h2>Welcome to BallotBot</h2> 
+            <p>Please click the button above to create a new ballot!</p>
+            <p>Once you've created your ballot, copy the link in the address bar and send to friends or colleagues to get responses</p>
+        </div>
+    );
+}

--- a/src/components/showBallot.jsx
+++ b/src/components/showBallot.jsx
@@ -1,14 +1,14 @@
 import { useState, useRef, useEffect } from 'react';
 import ClipboardButton from './clipboardButton';
+import { formatTimeLeft } from '../utils';
 
 export default function ShowBallot({ ballot }) {
     const [secondsLeft, setSecondsLeft] = useState(ballot.exp_s - ballot.seconds_since_creation);
 
-    const decrease = () => setSecondsLeft(prev => prev - 1);
     let intervalRef = useRef();
 
     useEffect(() => {
-        intervalRef.current = setInterval(decrease, 1000);
+        intervalRef.current = setInterval(() => setSecondsLeft(prev => prev - 1), 1000);
 
         return () => clearInterval(intervalRef.current);
     }, []);
@@ -21,18 +21,11 @@ export default function ShowBallot({ ballot }) {
             </div>));
     }
 
-    const formatTimeLeft = () => {
-        if (secondsLeft <= 0) {
-            return "Ballot closed!";
-        }
-        return `Ballot closes in ${Math.floor(secondsLeft / 60)}:${secondsLeft % 60 < 10 ? "0" + secondsLeft % 60 : secondsLeft % 60}`;
-    };
-
     return (
         <div id='ballot'>
             <h1>{ballot.title}</h1>
             <ClipboardButton />
-            <p id='time-left'>{formatTimeLeft()}</p>
+            <p id='time-left'>{formatTimeLeft(secondsLeft)}</p>
             {renderResponses(ballot.responses)}
         </div>
     );

--- a/src/components/voteForm.jsx
+++ b/src/components/voteForm.jsx
@@ -1,0 +1,65 @@
+import { fetchBallotById, formatTimeLeft } from '../utils';
+import { useState, useRef, useEffect } from 'react';
+import { Form } from 'react-router-dom';
+import ClipboardButton from '../components/clipboardButton';
+import Ballot from '../components/ballot';
+
+export default function VoteForm({ id }) {    
+
+    const [ballot, setBallot] = useState({ pubId: null, title: "", seconds_since_creation: null, exp_s: null, responses: [] });
+    const [secondsLeft, setSecondsLeft] = useState(ballot.exp_s - ballot.seconds_since_creation);
+    const [timeRunning, setTimeRunning] = useState(false);
+
+    let intervalRef = useRef();
+
+    useEffect(() => {
+        async function fetchData() {
+            setBallot(await fetchBallotById(id));
+        }
+        fetchData();
+
+        return () => clearInterval(intervalRef.current);
+    }, []);
+
+    useEffect(() => {
+        if (secondsLeft <= 0) {
+            setSecondsLeft(0);
+            clearInterval(intervalRef.current);
+        }
+    }, [secondsLeft]);
+
+    useEffect(() => {
+        setSecondsLeft(ballot.exp_s - ballot.seconds_since_creation);
+        if (!timeRunning) {
+            intervalRef.current = setInterval(() => setSecondsLeft(prev => prev - 1), 1000);
+            setTimeRunning(true);
+        }
+    }, [ballot]);
+
+    const renderChoices = () => {
+        return ballot.responses.map(r => (
+            <div className='responses' key={r.pubId}>
+                <input className="responses-radio" value={r.pubId} type='radio' name='picked' /><span>{r.content}</span>
+            </div>));
+    };
+
+    const renderFormOrShowBallot = () => {
+        if (secondsLeft > 0) {
+            return (
+                <Form method='post' id='ballot'>
+                    <h1>{ballot.title}</h1>
+                    <ClipboardButton />
+                    <p id='time-left'>{formatTimeLeft(secondsLeft)}</p>
+                    {renderChoices()}
+                    <button type='submit' id='vote-btn'>Cast Vote</button>
+                </Form>
+            );
+        } else {
+            return ballot.pubId ? <Ballot id={ballot.pubId} /> : "";
+        }
+    };
+
+    return (
+        renderFormOrShowBallot()
+    );
+}

--- a/src/components/voteForm.jsx
+++ b/src/components/voteForm.jsx
@@ -1,22 +1,11 @@
-import { formatTimeLeft } from '../utils';
+import { calculateExpiry, formatTimeLeft } from '../utils';
 import { useState, useRef, useEffect } from 'react';
 import { Form } from 'react-router-dom';
 import ClipboardButton from '../components/clipboardButton';
 import Ballot from '../components/ballot';
 
 export default function VoteForm({ ballot }) {    
-
-    const calculateExpiry = ballot => {
-        const secondsSinceCreation = Math.floor((new Date() - new Date(ballot.created_utc)) / 1000);
-        
-        const timeLeft = ballot.exp_s - secondsSinceCreation;
-
-        return timeLeft <= 0 ? 0 : timeLeft;
-    };
-
-    const [secondsLeft, setSecondsLeft] = useState(1);
-
-    console.log(secondsLeft);
+    const [secondsLeft, setSecondsLeft] = useState(calculateExpiry(ballot));
 
     let intervalRef = useRef();
 
@@ -62,7 +51,7 @@ export default function VoteForm({ ballot }) {
                 </Form>
             );
         } else {
-            return ballot.pubId ? <Ballot id={ballot.pubId} /> : "";
+            return <Ballot ballot={ballot} />;
         }
     };
 

--- a/src/components/voteForm.jsx
+++ b/src/components/voteForm.jsx
@@ -9,15 +9,6 @@ export default function VoteForm({ ballot }) {
 
     let intervalRef = useRef();
 
-    // const debug = {
-    //     ballot_created: new Date(ballot.created_utc),
-    //     now: new Date(),
-    // };
-    // console.log("Ballot created at: " + debug.ballot_created);
-    // console.log("Right now: " + debug.now);
-    // console.log("Time since creation in seconds: " + (debug.now - debug.ballot_created) / 1000);
-
-
     useEffect(() => {
         intervalRef.current = setInterval(() => setSecondsLeft(prev => prev - 1), 1000);
 

--- a/src/index.css
+++ b/src/index.css
@@ -150,3 +150,7 @@ li:hover {
     width: fit-content;
     margin: 0 auto;
 }
+
+#intro-message {
+    font-size: 1.5rem;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -9,7 +9,7 @@ import ErrorPage from './error-page';
 import NewBallot, { action as newAction } from './routes/new';
 import Ballot, { 
     loader as ballotLoader 
-} from './routes/ballot';
+} from './routes/show';
 import VoteBallot, { 
     loader as voteBallotLoader, 
     action as voteBallotAction 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,11 +6,13 @@ import {
 } from 'react-router-dom';
 import Root from './routes/root';
 import ErrorPage from './error-page';
-import NewBallot, { action as newAction } from './routes/new';
+import NewBallot, { 
+    action as newAction 
+} from './routes/new';
 import Ballot, { 
     loader as ballotLoader 
 } from './routes/show';
-import VoteBallot, { 
+import EditBallot, { 
     loader as voteBallotLoader, 
     action as voteBallotAction 
 } from './routes/edit';
@@ -36,7 +38,7 @@ const router = createBrowserRouter([
                 path: '/vote/:ballotId',
                 action: voteBallotAction,
                 loader: voteBallotLoader,
-                element: <VoteBallot />,
+                element: <EditBallot />,
             },
         ]
     },

--- a/src/routes/edit.jsx
+++ b/src/routes/edit.jsx
@@ -1,6 +1,7 @@
 import { useLoaderData, Form, redirect } from 'react-router-dom';
 import { useRef, useEffect, useState } from 'react';
 import Ballot from '../components/Ballot';
+import VoteForm from '../components/VoteForm';
 import ClipboardButton from '../components/clipboardButton';
 import { fetchBallotById, formatTimeLeft } from '../utils';
 
@@ -34,50 +35,7 @@ const updateResponsePatchRequest = async (ballotId, responseId) => {
 }
 
 export default function EditBallot() {
-
     const ballot = useLoaderData();
-    const [secondsLeft, setSecondsLeft] = useState(ballot.exp_s - ballot.seconds_since_creation);
 
-    let intervalRef = useRef();
-
-    useEffect(() => {
-        intervalRef.current = setInterval(() => setSecondsLeft(prev => prev - 1), 1000);
-
-        return () => clearInterval(intervalRef.current);
-    }, []);
-
-    useEffect(() => {
-        if (secondsLeft <= 0) {
-            setSecondsLeft(0);
-            clearInterval(intervalRef.current);
-        }
-    }, [secondsLeft]);
-
-    const renderChoices = () => {
-        return ballot.responses.map(r => (
-            <div className='responses' key={r.pubId}>
-                <input className="responses-radio" value={r.pubId} type='radio' name='picked' /><span>{r.content}</span>
-            </div>));
-    };
-    console.log(secondsLeft);
-
-    const renderFormOrShowBallot = () => {
-        if (secondsLeft > 0) {
-            return (
-                <Form method='post' id='ballot'>
-                    <h1>{ballot.title}</h1>
-                    <ClipboardButton />
-                    <p id='time-left'>{formatTimeLeft(secondsLeft)}</p>
-                    {renderChoices()}
-                    <button type='submit' id='vote-btn'>Cast Vote</button>
-                </Form>
-            );
-        } else {
-            return <Ballot ballot={ballot} />
-        }
-    };
-
-    return (
-        renderFormOrShowBallot()
-    );
+    return <VoteForm id={ballot.pubId} />;
 }

--- a/src/routes/edit.jsx
+++ b/src/routes/edit.jsx
@@ -33,7 +33,7 @@ const updateResponsePatchRequest = async (ballotId, responseId) => {
     return redirect("/" + ballotId);
 }
 
-export default function VoteBallot() {
+export default function EditBallot() {
 
     const ballot = useLoaderData();
     const [secondsLeft, setSecondsLeft] = useState(ballot.exp_s - ballot.seconds_since_creation);

--- a/src/routes/edit.jsx
+++ b/src/routes/edit.jsx
@@ -37,7 +37,6 @@ export default function VoteBallot() {
 
     const ballot = useLoaderData();
     const [secondsLeft, setSecondsLeft] = useState(ballot.exp_s - ballot.seconds_since_creation);
-    const [ballotIsOpen, setBallotIsOpen] = useState(ballot.exp_s > ballot.seconds_since_creation);
 
     let intervalRef = useRef();
 
@@ -50,7 +49,6 @@ export default function VoteBallot() {
     useEffect(() => {
         if (secondsLeft <= 0) {
             setSecondsLeft(0);
-            setBallotIsOpen(false);
             clearInterval(intervalRef.current);
         }
     }, [secondsLeft]);
@@ -63,7 +61,7 @@ export default function VoteBallot() {
     };
 
     const renderFormOrShowBallot = () => {
-        if (ballotIsOpen) {
+        if (secondsLeft <= 0) {
             return (
                 <Form method='post' id='ballot'>
                     <h1>{ballot.title}</h1>

--- a/src/routes/edit.jsx
+++ b/src/routes/edit.jsx
@@ -1,6 +1,6 @@
 import { useLoaderData, Form, redirect } from 'react-router-dom';
 import { useRef, useEffect, useState } from 'react';
-import ShowBallot from '../components/showBallot';
+import Ballot from '../components/Ballot';
 import ClipboardButton from '../components/clipboardButton';
 import { fetchBallotById, formatTimeLeft } from '../utils';
 
@@ -59,9 +59,10 @@ export default function EditBallot() {
                 <input className="responses-radio" value={r.pubId} type='radio' name='picked' /><span>{r.content}</span>
             </div>));
     };
+    console.log(secondsLeft);
 
     const renderFormOrShowBallot = () => {
-        if (secondsLeft <= 0) {
+        if (secondsLeft > 0) {
             return (
                 <Form method='post' id='ballot'>
                     <h1>{ballot.title}</h1>
@@ -72,7 +73,7 @@ export default function EditBallot() {
                 </Form>
             );
         } else {
-            return <ShowBallot ballot={ballot} />
+            return <Ballot ballot={ballot} />
         }
     };
 

--- a/src/routes/edit.jsx
+++ b/src/routes/edit.jsx
@@ -37,5 +37,5 @@ const updateResponsePatchRequest = async (ballotId, responseId) => {
 export default function EditBallot() {
     const ballot = useLoaderData();
 
-    return <VoteForm id={ballot.pubId} />;
+    return <VoteForm ballot={ballot} />;
 }

--- a/src/routes/new.jsx
+++ b/src/routes/new.jsx
@@ -81,7 +81,6 @@ export default function NewBallot() {
             <div className='response-field'>
                 <span className='new-form-label'>Time limit in minutes</span>
                 <select name="timer" className='new-ballot-inp'>
-                    <option value="1">1 minute DEBUG</option>
                     <option value="5">5 minutes</option>
                     <option value="10">10 minutes</option>
                     <option value="20">20 minutes</option>

--- a/src/routes/new.jsx
+++ b/src/routes/new.jsx
@@ -81,6 +81,7 @@ export default function NewBallot() {
             <div className='response-field'>
                 <span className='new-form-label'>Time limit in minutes</span>
                 <select name="timer" className='new-ballot-inp'>
+                    <option value="1">1 minute DEBUG</option>
                     <option value="5">5 minutes</option>
                     <option value="10">10 minutes</option>
                     <option value="20">20 minutes</option>

--- a/src/routes/root.jsx
+++ b/src/routes/root.jsx
@@ -1,20 +1,15 @@
 import { useLocation, Link, Outlet } from 'react-router-dom';
+import HelloMessage from '../components/hello';
 
 export default function Root() {
 
     const location = useLocation();
 
-    // const renderHello = () => {
-    //     return (
-    //             <h2><u>Welcome to BallotBot.</u></h2> <p>Please click the button above to create a new ballot!</p>
-    //             <p>Once you've created your ballot, copy the link in the address bar and send to friends or colleagues to get responses</p>
-    //     )
-    // };
-
     return (
         <>
             <header>
                 <h1 id='title'>Ballot Bot</h1>
+                {location.pathname === "/" ? <HelloMessage /> : ""}
                 <ul id='nav'>
                     <li>
                         <Link to='/new'>Create Ballot</Link>

--- a/src/routes/show.jsx
+++ b/src/routes/show.jsx
@@ -11,6 +11,6 @@ export default function ShowBallot() {
     const ballot = useLoaderData();
 
     return (
-        <Ballot ballot={ballot} />
+        <Ballot id={ballot.pubId} />
     );
 }

--- a/src/routes/show.jsx
+++ b/src/routes/show.jsx
@@ -11,6 +11,6 @@ export default function ShowBallot() {
     const ballot = useLoaderData();
 
     return (
-        <Ballot id={ballot.pubId} />
+        <Ballot ballot={ballot} />
     );
 }

--- a/src/routes/show.jsx
+++ b/src/routes/show.jsx
@@ -1,16 +1,16 @@
 import { useLoaderData } from 'react-router-dom';
 import { useEffect, useRef, useState } from 'react';
 import { fetchBallotById } from '../utils';
-import ShowBallot from '../components/showBallot';
+import Ballot from '../components/Ballot';
 
 export async function loader({ params }) {
     return await fetchBallotById(params.ballotId);
 }
 
-export default function Ballot() {
+export default function ShowBallot() {
     const ballot = useLoaderData();
 
     return (
-        <ShowBallot ballot={ballot} />
+        <Ballot ballot={ballot} />
     );
 }

--- a/src/routes/show.jsx
+++ b/src/routes/show.jsx
@@ -1,17 +1,11 @@
 import { useLoaderData } from 'react-router-dom';
-import ShowBallot from '../components/showBallot';
 import { useEffect, useRef, useState } from 'react';
+import { fetchBallotById } from '../utils';
+import ShowBallot from '../components/showBallot';
 
 export async function loader({ params }) {
     return await fetchBallotById(params.ballotId);
 }
-
-const fetchBallotById = async id => {
-    const response = await fetch(import.meta.env.VITE_API_ROOT + "/polls/" + id);
-    const json = await response.json();
-    return json; 
-}
-
 
 export default function Ballot() {
     const ballot = useLoaderData();

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,13 @@
+export const fetchBallotById = async id => {
+    const response = await fetch(import.meta.env.VITE_API_ROOT + "/polls/" + id);
+    return await response.json();
+};
+
+
+export const formatTimeLeft = s => {
+    if (s <= 0) {
+        return "Ballot closed!";
+    }
+    return `Ballot closes in ${Math.floor(s / 60)}:${s % 60 < 10 ? "0" + s % 60 : s % 60}`;
+};
+

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,3 +11,10 @@ export const formatTimeLeft = s => {
     return `Ballot closes in ${Math.floor(s / 60)}:${s % 60 < 10 ? "0" + s % 60 : s % 60}`;
 };
 
+export const calculateExpiry = ballot => {
+    const secondsSinceCreation = Math.floor((new Date() - new Date(ballot.created_utc)) / 1000);
+
+    const timeLeft = ballot.exp_s - secondsSinceCreation;
+
+    return timeLeft <= 0 ? 0 : timeLeft;
+};


### PR DESCRIPTION
The idea in the first few commits was to allow Ballot and VoteForm to be able to get updated ballot objects from network when they were rendered, as the server was doing the work to determine when the ballot was going to expire (exp_s property). Several associated state variables have been removed from Ballot and VoteForm as well, as they were only required for the additional networking that was eventually removed in the latter commits.

The server has been reworked to return a UTC iso8601 timestamp of when the ballot was created, so the expiry work can now be done at will client-side. This allowed me to remove the extra network calls I introduced to both VoteForm and Ballot, and instead calculate the time the ballot expires using Date math given the UTC timestamp. This is done in calculateExpiry in utils.js

In addition, I reworked the file structure so that the route files represent the routes they serve (show, edit, new etc), and the components are named more like the objects they display (Ballot, VoteForm).